### PR TITLE
ci: shared workflow for using a cloud builder

### DIFF
--- a/.github/workflows/bake-publish-cloud-builder.yaml
+++ b/.github/workflows/bake-publish-cloud-builder.yaml
@@ -1,0 +1,145 @@
+---
+  # This is a reusable workflow for building and publishing Docker images
+  # using a bake file and building using Docker Cloud Builder
+  
+  name: Simple Bake & Publish
+  on:
+    workflow_call:
+      inputs:
+        file:
+          description: 'The file name of the bake file to use. If not provided will use default.'
+          type: string
+          default: 'docker-bake.hcl'
+          required: false
+        group:
+          description: 'Group to use from the bake file.'
+          type: string
+          default: ''
+          required: true
+        registry:
+          description: 'The container registry to use.'
+          type: string
+          default: 'ghcr.io'
+          required: false
+        organization:
+          description: 'The organization to use for the docker image'
+          type: string
+          required: true
+      secrets:
+        username:
+          description: 'Username for the docker registry'
+          required: true
+        token:
+          description: 'PAT for the docker registry'
+          required: true
+        endpoint:
+          description: 'The endpoint for the docker cloud builder'
+          required: true
+  
+  jobs:
+    # Generate a matrix based on all the targets defined in the
+    # bake file. The reason for this is to parallelize the build
+    # process and allow for docker layer caching to be saved
+    # for each, otherwise they would overwrite the same cache.
+    targets:
+      name: Generate targets list from provided bake file
+      runs-on: ubuntu-22.04
+      outputs:
+        targets: ${{ steps.generate.outputs.targets }}
+
+      steps:
+        # 1.1 - checkout the files
+        - name: Checkout
+          uses: actions/checkout@v4
+
+        # 1.2 - Generate a matrix output of all the targets for the specified group
+        - name: List targets
+          id: generate
+          uses: docker/bake-action/subaction/list-targets@v4.1.0
+          with:
+            target: ${{ inputs.group }}
+            files: ${{ inputs.file }}
+
+        # 1.3 (optional) - output the generated target list for verification
+        - name: Show matrix
+          run: |
+            echo ${{ steps.generate.outputs.targets }}
+  
+    build-push:
+      # NOTE: this name is used for waiting on in the retag workflow
+      name: build-bake-push
+      runs-on: ubuntu-22.04
+      permissions:
+        packages: write
+        contents: read
+      # this job depends on the 'targets' job
+      needs:
+        - targets
+  
+      # 2.0 - Build a matrix strategy from the retrieved target list
+      strategy:
+        fail-fast: true
+        matrix:
+          target: ${{ fromJson(needs.targets.outputs.targets) }}
+  
+      steps:
+        # 2.1 - Checkout the repository
+        - name: Checkout the repository
+          uses: actions/checkout@v4
+  
+        # 2.2 - Generate Image Metadata
+        # Automatically generates the defaul OCI labels that can be extended
+        # Automatically determine the version tag to use based by the following
+        # priority list:
+        #   - if tag is semantic version compliant use the version (strip prefix/suffix)
+        #   - if tagged but not semver, use tag directly
+        #   - if no tag use PR branch
+        #   - if neither of the above and is default branch then use latest
+        # NOTE: that all 3 may be generated as tags but the priority for the version
+        # to be embedded within the image label is top to bottom
+        - name: Docker meta
+          id: meta
+          uses: docker/metadata-action@v5.5.0
+          with:
+            images: ghcr.io/${{ github.repository }}
+            tags: |
+              type=semver,pattern={{version}}
+              type=ref,event=tag
+              type=ref,event=pr
+              # set latest tag for default branch
+              type=raw,value=latest,enable={{is_default_branch}}
+
+        # 2.3 - Login against the docker registry
+        - name: Login to registry GHCR
+          uses: docker/login-action@v3.0.0
+          with:
+            registry: ghcr.io
+            username: ${{ github.repository_owner }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+
+        # 2.4 - Login against the Docker registry
+        - name: Login to registry Docker Cloud
+          uses: docker/login-action@v3.0.0
+          with:
+            username: ${{ secrets.username }}
+            password: ${{ secrets.token }}
+
+        # 2.5 - Setup Docker BuildX for multi platform Cloud building
+        # NOTE: Experimental
+        - name: Set up Docker Buildx
+          uses: docker/setup-buildx-action@v3.0.0
+          with:
+            version: "lab:latest"
+            driver: cloud
+            endpoint: "${{ secrets.endpoint }}"
+
+        # 2.6 - Build Docker Images
+        - name: Build Images using BuildX Bake
+          uses: docker/bake-action@v4.1.0
+          with:
+            files: |
+              ${{ inputs.file }}
+              ${{ steps.meta.outputs.bake-file }}
+            targets: ${{ matrix.target }}
+            push: true
+  

--- a/.github/workflows/bake-publish-cloud-builder.yaml
+++ b/.github/workflows/bake-publish-cloud-builder.yaml
@@ -101,7 +101,7 @@
           id: meta
           uses: docker/metadata-action@v5.5.0
           with:
-            images: ghcr.io/${{ github.repository }}
+            images: ghcr.io/${{ github.repository_owner }}/${{ matrix.target }}
             tags: |
               type=semver,pattern={{version}}
               type=ref,event=tag

--- a/.github/workflows/bake-publish.yaml
+++ b/.github/workflows/bake-publish.yaml
@@ -123,9 +123,6 @@ jobs:
       # 2.5 - Setup Docker BuildX for multi platform building
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        with:
-          driver-opts: |
-            image=moby/buildkit:v0.10.6
 
       # 2.6 - Build and push Docker Images
       - name: Build Images using BuildX Bake

--- a/.github/workflows/bake-publish.yml
+++ b/.github/workflows/bake-publish.yml
@@ -123,9 +123,6 @@ jobs:
       # 2.5 - Setup Docker BuildX for multi platform building
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        with:
-          driver-opts: |
-            image=moby/buildkit:v0.10.6
 
       # 2.6 - Build and push Docker Images
       - name: Build Images using BuildX Bake

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.DS_Store


### PR DESCRIPTION
Adding shared workflow for use with `docker cloud builder` for building and pushing multi-arch images.
This PR completely adds a new simple worfklow to leverage Docker Cloud Builders. Secrets have been pushed to leverage the builder within its configuration but note that SECRETS are available only within the Julia repos currently.

1.  This is experimental feature that has limited CI minutes (not GH CI minutes), please use sparingly.
2.  Bake file updated to leverage the metadata action from the CI, local builds are still available.

NOTE: If builds fail please notify @Nithos , we may have run through our allocated minutes
NOTE: There is an option that we could run local AMD builds on GH directly for testing, and only build both arch for prod use, but for now to keep things simply we are leveraging the cloud builder for all and its cache system.
